### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Proof HTML
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GameStoreio/Gaming_Store/security/code-scanning/1](https://github.com/GameStoreio/Gaming_Store/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the GITHUB_TOKEN. Since the workflow only runs the `anishathalye/proof-html` action, which reads files in the repository and does not require write access, it is sufficient to grant only `contents: read` permission. The `permissions` block should be added at the workflow level (as a top-level key, after `name:` and before `on:`), so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
